### PR TITLE
fix: ActivePanelManager에서 Dictionary 할당 오류

### DIFF
--- a/Cat_Merge/Assets/1.Scripts/GameManagement/ActivePanelManager.cs
+++ b/Cat_Merge/Assets/1.Scripts/GameManagement/ActivePanelManager.cs
@@ -21,7 +21,7 @@ public class ActivePanelManager : MonoBehaviour
 
     // ======================================================================================================================
 
-    private void Start()
+    private void Awake()
     {
         panels = new Dictionary<string, PanelInfo>();
         activePanelName = null;


### PR DESCRIPTION
1. 실행 순서 때문에 오류 (Start -> Awake로 변경)